### PR TITLE
Construct correctly even without new.

### DIFF
--- a/lib/ZabbixSender.js
+++ b/lib/ZabbixSender.js
@@ -17,6 +17,10 @@ function log() {
  */
 function ZabbixSender(options) {
 
+  if (!(this instanceof ZabbixSender)) {
+    return new ZabbixSender(options);
+  }
+
 	options = options || {};
 
 	this.options = {

--- a/test/unit/ZabbixSenderTest.js
+++ b/test/unit/ZabbixSenderTest.js
@@ -20,6 +20,22 @@ describe('constructer()', function() {
 	});
 });
 
+describe('call without new', function() {
+	it('checking default options', function() {
+		var sender = ZabbixSender();
+		expect(sender.options).to.be.deep.equal({
+			config : '/etc/zabbix/zabbix_agentd.conf',
+			bin : binLocation,
+			debug : false,
+			log : false,
+			hostname : '-',
+			port : undefined,
+			server : undefined,
+			joinString : '.'
+		});
+	});
+});
+
 describe('ZabbixSender.send()', function() {
 	var endSpy;
 	var execStub;


### PR DESCRIPTION
This allows ZabbixSender objects to be created correctly even if the new operator is omitted, e.g.:
`var sender = ZabbixSender();`