### PR TITLE
Make sure stream errors don't crash the process with EPIPE.

### DIFF
--- a/lib/ZabbixSender.js
+++ b/lib/ZabbixSender.js
@@ -57,7 +57,9 @@ ZabbixSender.prototype.send = function(data, errorCallback) {
 	}
 
 	if (!this.options.debug) {
-		execFile(this.options.bin, cmdArgs, errorCallback).stdin.end(stdIn);
+		var stdin = execFile(this.options.bin, cmdArgs, errorCallback).stdin;
+		stdin.on ('error', function () {/* Ignore errors */});
+		stdin.end(stdIn);
 	}
 	return this;
 };

--- a/test/unit/ZabbixSenderTest.js
+++ b/test/unit/ZabbixSenderTest.js
@@ -21,15 +21,18 @@ describe('constructer()', function() {
 });
 
 describe('ZabbixSender.send()', function() {
+	var onSpy;
 	var endSpy;
 	var execStub;
 	var ZabbixSenderFakeExec;
 	var expectedDefaultEncodedOptions = ['--config', '/etc/zabbix/zabbix_agentd.conf', '--input-file', '-'];
 
 	beforeEach(function() {
+		onSpy = sinon.spy();
 		endSpy = sinon.spy();
 		execStub = sinon.stub().returns({
 			stdin : {
+				on : onSpy,
 				end : endSpy
 			}
 		});
@@ -53,6 +56,7 @@ describe('ZabbixSender.send()', function() {
 					expectedDefaultEncodedOptions,
 					undefined
 					);
+			expect(onSpy).to.be.called.Once;
 			expect(endSpy).to.be.called.Once;
 
 		});
@@ -67,6 +71,7 @@ describe('ZabbixSender.send()', function() {
 					['--config', './test/file.js', '--input-file', '-'],
 					undefined
 					);
+			expect(onSpy).to.be.called.Once;
 			expect(endSpy).to.be.called.Once;
 		});
 
@@ -80,6 +85,7 @@ describe('ZabbixSender.send()', function() {
 					expectedDefaultEncodedOptions,
 					undefined
 					);
+			expect(onSpy).to.be.called.Once;
 			expect(endSpy).to.be.called.Once;
 		});
 
@@ -93,6 +99,7 @@ describe('ZabbixSender.send()', function() {
 					['--config', '/etc/zabbix/zabbix_agentd.conf', '--port', 12345, '--input-file', '-'],
 					undefined
 					);
+			expect(onSpy).to.be.called.Once;
 			expect(endSpy).to.be.called.Once;
 		});
 
@@ -106,6 +113,7 @@ describe('ZabbixSender.send()', function() {
 					expectedDefaultEncodedOptions,
 					undefined);
 
+			expect(onSpy).to.be.called.Once;
 			expect(endSpy).to.be.called.Once;
 		});
 
@@ -119,6 +127,7 @@ describe('ZabbixSender.send()', function() {
 					expectedDefaultEncodedOptions,
 					undefined);
 
+			expect(onSpy).to.be.called.Once;
 			expect(endSpy).to.be.called.Once;
 			expect(endSpy).always.have.been.calledWithExactly('HOSTNAME key value\n');
 		});
@@ -137,6 +146,7 @@ describe('ZabbixSender.send()', function() {
 					errorCallback);
 
 			expect(errorCallback).to.be.not.called;
+			expect(onSpy).to.be.called.Once;
 			expect(endSpy).to.be.called.Once;
 
 		});
@@ -155,6 +165,7 @@ describe('ZabbixSender.send()', function() {
 					expectedDefaultEncodedOptions,
 					undefined);
 
+			expect(onSpy).to.be.called.Once;
 			expect(endSpy).to.be.called.Once;
 			expect(endSpy).always.have.been.calledWithExactly('- keyA.keyB propC\n');
 		});
@@ -168,6 +179,7 @@ describe('ZabbixSender.send()', function() {
 					expectedDefaultEncodedOptions,
 					undefined);
 
+			expect(onSpy).to.be.called.Once;
 			expect(endSpy).to.be.called.Once;
 			expect(endSpy).always.have.been.calledWithExactly('- NaNaNaNa 123\n');
 		});
@@ -192,6 +204,7 @@ describe('ZabbixSender.send()', function() {
 								expectedDefaultEncodedOptions,
 								undefined);
 
+						expect(onSpy).to.be.called.Once;
 						expect(endSpy).to.be.called.Once;
 						expect(endSpy).always.have.been.calledWithExactly('- keyA' + joinString + 'keyB propC\n');
 					});
@@ -205,6 +218,7 @@ describe('ZabbixSender.send()', function() {
 								expectedDefaultEncodedOptions,
 								undefined);
 
+						expect(onSpy).to.be.called.Once;
 						expect(endSpy).to.be.called.Once;
 						expect(endSpy).always.have.been.calledWithExactly('- keyA' + joinString + 'keyB' + joinString + 'keyC propD\n');
 					});
@@ -223,6 +237,7 @@ describe('ZabbixSender.send()', function() {
 								expectedDefaultEncodedOptions,
 								undefined);
 
+						expect(onSpy).to.be.called.Once;
 						expect(endSpy).to.be.called.Once;
 						expect(endSpy).always.have.been.calledWithExactly('- keyA' + joinString + 'keyB' + joinString + 'keyC propD\n- keyA' + joinString + 'keyX propZ\n');
 					});


### PR DESCRIPTION
This can happen if the zabbix-sender process exits (eg if the Zabbix config
is missing required parameters) before the stream is written to.